### PR TITLE
DOS and IOCS function fixes

### DIFF
--- a/newlib/libc/sys/human68k/crt0.S
+++ b/newlib/libc/sys/human68k/crt0.S
@@ -47,18 +47,22 @@ clear_bss:
 
 | Save crt0 arguments
 	move.l	%a0, _MCB		| MCB
+	move.l	%a0, _memcp		| pointer version
 	lea.l	%a0@(0x100), %a5
 	move.l	%a5, _PSTA		| TEXT Start
+	move.l	%a5, _psta		| pointer version
 	move.l	%a0@(0x34), %d0
 	move.l	%d0, _PEND		| TEXT End
 	move.l	%d0, _DSTA		| DATA Start
 	move.l	%a0@(0x30), %d0
 	move.l	%d0, _DEND		| DATA End
 	move.l	%d0, _BSTA		| BSS Start
+	move.l	%d0, _bsta		| pointer version
 	move.l	%a1, _BEND		| BSS End
 
 	lea.l	%a0@(0x10), %a5
 	move.l	%a5, _PSP
+	move.l	%a5, _procp		| pointer version
 
 | Setup environment
 	move.l	%a3, _ENV0
@@ -68,16 +72,22 @@ clear_bss:
 
 | Setup stack
 	move.l	%a1, _SSTA
+	move.l	%a1, _ssta		| pointer version
 	add.l	#STACK_SIZE, %a1
+	move.l  #STACK_SIZE, _stacksize
 	move.l	%a1, _SEND
 
 	move.l	%a1, %sp
 	
 | Setup heap
 	move.l	%a1, _HSTA		| HEAP Start
+	move.l	%a1, _hsta		| pointer version
 	add.l	#HEAP_SIZE, %a1
+	move.l  #HEAP_SIZE, _heapsize
 	move.l	%a1, _HEND		| HEAP End
+	move.l	%a1, _last		| pointer version
 	move.l	%a0@(0x08), _HMAX	| End block
+	move.l	%a0@(0x08), _mmax	| pointer version
 
 	lea.l	%a0@(0x10), %a5		| PSP
 
@@ -98,19 +108,33 @@ clear_bss:
 |
 
 	.comm	_MCB, 4
+	.comm	_memcp, 4		| pointer version
 	.comm	_PSP, 4
+	.comm	_procp, 4		| pointer version
 
 	.comm	_PSTA, 4
+	.comm	_psta, 4		| pointer version
 	.comm	_PEND, 4
 	.comm	_DSTA, 4
 	.comm	_DEND, 4
 	.comm	_BSTA, 4
+	.comm	_bsta, 4		| pointer version
 	.comm	_BEND, 4
 	.comm	_SSTA, 4
+	.comm	_ssta, 4		| pointer version
+	.comm	_stacksize, 4
+	
+	
 	.comm	_SEND, 4
 	.comm	_HSTA, 4
+	.comm	_hsta, 4		| pointer version
 	.comm	_HEND, 4
+	.comm	_last, 4		| pointer version
+	.comm	_heapsize, 4
+	
+	
 	.comm	_HMAX, 4
+	.comm	_mmax, 4		| pointer version
 
 	.comm	_ENV0, 4
 

--- a/newlib/libc/sys/human68k/include/dos.h
+++ b/newlib/libc/sys/human68k/include/dos.h
@@ -250,7 +250,7 @@ struct dos_filbuf {
 	unsigned short	date;
 	unsigned int	filelen;
 	char		name[23];
-} __attribute__((__packed__));
+}; //__attribute__((__packed__));
 
 struct dos_exfilbuf {
 	unsigned char	searchatr;

--- a/newlib/libc/sys/human68k/include/iocs.h
+++ b/newlib/libc/sys/human68k/include/iocs.h
@@ -4,7 +4,7 @@
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
-typedef unsigned int iocs_color_t;
+typedef unsigned short iocs_color_t;
 
 struct iocs_boxptr {
   short	x1;

--- a/newlib/libc/sys/human68k/include/iocs.h
+++ b/newlib/libc/sys/human68k/include/iocs.h
@@ -258,7 +258,7 @@ extern void	_iocs_b_era_ed (void);
 extern void	_iocs_b_era_st (void);
 extern int	_iocs_b_format (int, int, int, const void *);
 extern void	_iocs_b_ins (int);
-extern void *	_iocs_b_intvcs (int vector, void *addr);
+extern void *	_iocs_b_intvcs (int vector, int addr);
 extern int	_iocs_b_keyinp (void);
 extern int	_iocs_b_keysns (void);
 extern void	_iocs_b_left (int);

--- a/newlib/libc/sys/human68k/include/iocs.h
+++ b/newlib/libc/sys/human68k/include/iocs.h
@@ -425,7 +425,7 @@ extern int	_iocs_tpalet2 (int, int);
 extern void	_iocs_tvctrl (int);
 extern void	_iocs_txbox (const struct iocs_tboxptr *);
 extern void	_iocs_txfill (const struct iocs_txfillptr *);
-extern void	_iocs_txline (struct iocs_tlineptr); /* 1.3 & iocs.x */
+extern void	_iocs_txline (struct iocs_tlineptr *); /* 1.3 & iocs.x */
 extern void	_iocs_txrascpy (int, int, int);
 extern void	_iocs_txrev (const struct iocs_trevptr *);
 extern void	_iocs_txxline (const struct iocs_xlineptr *);

--- a/newlib/libc/sys/human68k/libdos/common_ck.S
+++ b/newlib/libc/sys/human68k/libdos/common_ck.S
@@ -6,7 +6,7 @@
 _dos_common_ck:
 	move.l	%sp@(4), %sp@-
 	clr.w	%sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/common_del.S
+++ b/newlib/libc/sys/human68k/libdos/common_del.S
@@ -6,7 +6,7 @@
 _dos_common_del:
 	move.l	%sp@(4), %sp@-
 	move.w	#5, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/common_fre.S
+++ b/newlib/libc/sys/human68k/libdos/common_fre.S
@@ -7,7 +7,7 @@ _dos_common_fre:
 	movem.l	%sp@(4), %d0-%d1/%a0-%a1
 	movem.l	%d0-%d1/%a0-%a1, %sp@-
 	move.w	#4, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/common_lk.S
+++ b/newlib/libc/sys/human68k/libdos/common_lk.S
@@ -7,7 +7,7 @@ _dos_common_lk:
 	movem.l	%sp@(4), %d0-%d1/%a0-%a1
 	movem.l	%d0-%d1/%a0-%a1, %sp@-
 	move.w	#3, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/common_rd.S
+++ b/newlib/libc/sys/human68k/libdos/common_rd.S
@@ -7,7 +7,7 @@ _dos_common_rd:
 	movem.l	%sp@(4), %d0-%d1/%a0-%a1
 	movem.l	%d0-%d1/%a0-%a1, %sp@-
 	move.w	#1, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/common_wt.S
+++ b/newlib/libc/sys/human68k/libdos/common_wt.S
@@ -7,7 +7,7 @@ _dos_common_wt:
 	movem.l	%sp@(4), %d0-%d1/%a0-%a1
 	movem.l	%d0-%d1/%a0-%a1, %sp@-
 	move.w	#2, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff85
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/fflush_set.S
+++ b/newlib/libc/sys/human68k/libdos/fflush_set.S
@@ -5,7 +5,7 @@
 .type _dos_fflush_set,@function
 _dos_fflush_set:
 	move.w	%sp@(6), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffaa
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/filedate.S
+++ b/newlib/libc/sys/human68k/libdos/filedate.S
@@ -6,7 +6,7 @@
 _dos_filedate:
 	move.l	%sp@(8), %sp@-
 	move.w	%sp@(10), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff87
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/files.S
+++ b/newlib/libc/sys/human68k/libdos/files.S
@@ -1,9 +1,9 @@
 | int _dos_files (struct _dos_filbuf *, const char *, int);
 .text
 .even
-.global _dos_filbuf
-.type _dos_filbuf,@function
-_dos_filbuf:
+.global _dos_files
+.type _dos_files,@function
+_dos_files:
 	move.w	%sp@(14), %sp@-
 	move.l	%sp@(10), %sp@-
 	move.l	%sp@(10), %sp@-

--- a/newlib/libc/sys/human68k/libdos/get_fcb_adr.S
+++ b/newlib/libc/sys/human68k/libdos/get_fcb_adr.S
@@ -5,7 +5,7 @@
 .type _dos_get_fcb_adr,@function
 _dos_get_fcb_adr:
 	move.w	%sp@(6), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffac
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/get_pr.S
+++ b/newlib/libc/sys/human68k/libdos/get_pr.S
@@ -1,9 +1,9 @@
 | int _dos_get_pr (int, struct _dos_prcptr *);
 .text
 .even
-.global _dos_prcptr
-.type _dos_prcptr,@function
-_dos_prcptr:
+.global _dos_get_pr
+.type _dos_get_pr,@function
+_dos_get_pr:
 	move.l	%sp@(8), %sp@-
 	move.w	%sp@(10), %sp@-
 	.short	0xfffa

--- a/newlib/libc/sys/human68k/libdos/getassign.S
+++ b/newlib/libc/sys/human68k/libdos/getassign.S
@@ -7,7 +7,7 @@ _dos_getassign:
 	move.l	%sp@(8), %sp@-
 	move.l	%sp@(8), %sp@-
 	clr.w	%sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8f
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/getenv.S
+++ b/newlib/libc/sys/human68k/libdos/getenv.S
@@ -6,7 +6,7 @@
 _dos_getenv:
 	movem.l	%sp@(4), %d0-%d1/%a0
 	movem.l	%d0-%d1/%a0, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff83
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/getpdb.S
+++ b/newlib/libc/sys/human68k/libdos/getpdb.S
@@ -4,7 +4,7 @@
 .global _dos_getpdb
 .type _dos_getpdb,@function
 _dos_getpdb:
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff81
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/load.S
+++ b/newlib/libc/sys/human68k/libdos/load.S
@@ -1,9 +1,9 @@
 | int _dos_load (const char *, const struct _dos_comline *, const char *);
 .text
 .even
-.global _dos_comline
-.type _dos_comline,@function
-_dos_comline:
+.global _dos_load
+.type _dos_load,@function
+_dos_load:
 	movem.l	%d2-%d7/%a2-%a6, %sp@-
 	movem.l	%sp@(48), %d0-%d1/%a0
 	movem.l	%d0-%d1/%a0, %sp@-

--- a/newlib/libc/sys/human68k/libdos/loadexec.S
+++ b/newlib/libc/sys/human68k/libdos/loadexec.S
@@ -1,9 +1,9 @@
 | int _dos_loadexec (const char *, const struct _dos_comline *, const char *);
 .text
 .even
-.global _dos_comline
-.type _dos_comline,@function
-_dos_comline:
+.global _dos_loadexec
+.type _dos_loadexec,@function
+_dos_loadexec:
 	movem.l	%d2-%d7/%a2-%a6, %sp@-
 	movem.l	%sp@(48), %d0-%d1/%a0
 	movem.l	%d0-%d1/%a0, %sp@-

--- a/newlib/libc/sys/human68k/libdos/lock.S
+++ b/newlib/libc/sys/human68k/libdos/lock.S
@@ -8,7 +8,7 @@ _dos_lock:
 	move.l	%sp@(12), %sp@-
 	move.w	%sp@(14), %sp@-
 	clr.w	%sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8c
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/makeassign.S
+++ b/newlib/libc/sys/human68k/libdos/makeassign.S
@@ -8,7 +8,7 @@ _dos_makeassign:
 	move.l	%sp@(10), %sp@-
 	move.l	%sp@(10), %sp@-
 	move.w	#1, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8f
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/maketmp.S
+++ b/newlib/libc/sys/human68k/libdos/maketmp.S
@@ -6,7 +6,7 @@
 _dos_maketmp:
 	move.w	%sp@(10), %sp@-
 	move.l	%sp@(6), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8a
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/malloc0.S
+++ b/newlib/libc/sys/human68k/libdos/malloc0.S
@@ -9,7 +9,7 @@ _dos_malloc0:
 	move.w	%sp@(14), %d0
 	or.w	#0x8000, %d0
 	move.w	%d0, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff88
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/malloc2.S
+++ b/newlib/libc/sys/human68k/libdos/malloc2.S
@@ -6,7 +6,7 @@
 _dos_malloc2:
 	move.l	%sp@(8), %sp@-
 	move.w	%sp@(10), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff88
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/move.S
+++ b/newlib/libc/sys/human68k/libdos/move.S
@@ -6,7 +6,7 @@
 _dos_move:
 	move.l	%sp@(8), %sp@-
 	move.l	%sp@(8), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff86
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/newfile.S
+++ b/newlib/libc/sys/human68k/libdos/newfile.S
@@ -6,7 +6,7 @@
 _dos_newfile:
 	move.w	%sp@(10), %sp@-
 	move.l	%sp@(6), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8b
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/nfiles.S
+++ b/newlib/libc/sys/human68k/libdos/nfiles.S
@@ -1,9 +1,9 @@
 | int _dos_nfiles (struct _dos_filbuf *);
 .text
 .even
-.global _dos_filbuf
-.type _dos_filbuf,@function
-_dos_filbuf:
+.global _dos_nfiles
+.type _dos_nfiles,@function
+_dos_nfiles:
 	move.l	%sp@(4), %sp@-
 	.short	0xff4f
 	addq.l	#4, %sp

--- a/newlib/libc/sys/human68k/libdos/open_pr.S
+++ b/newlib/libc/sys/human68k/libdos/open_pr.S
@@ -4,13 +4,15 @@
 .global _dos_open_pr
 .type _dos_open_pr,@function
 _dos_open_pr:
-	movem.l	%sp@(20), %d0-%d1/%a0-%a1
-	movem.l	%d1/%a0-%a1, %sp@-
-	move.w	%d0, %sp@-
-	move.l	%sp@(32), %sp@-
-	move.l	%sp@(32), %sp@-
-	move.w	%sp@(34), %sp@-
-	move.l	%sp@(30), %sp@-
+	move.l	%sp@(32), %sp@- |4, push long sleep_time
+    move.l	%sp@(32), %sp@- |4, push struct _dos_prcctrl* buff,
+    move.l	%sp@(32), %sp@- |4, push int pc
+    move.w	%sp@(32), %sp@- |2, push int sr
+
+	move.l	%sp@(30), %sp@- |4, push int ssp
+	move.l	%sp@(30), %sp@- |4, push int usp
+	move.w	%sp@(30), %sp@- |2, push int counter
+	move.l	%sp@(28), %sp@- |4, const char *name
 	.short	0xfff8
 	lea	%sp@(28), %sp
 	rts

--- a/newlib/libc/sys/human68k/libdos/os_patch.S
+++ b/newlib/libc/sys/human68k/libdos/os_patch.S
@@ -6,7 +6,7 @@
 _dos_os_patch:
 	move.l	%sp@(8), %sp@-
 	move.w	%sp@(10), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffab
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/pathchk.S
+++ b/newlib/libc/sys/human68k/libdos/pathchk.S
@@ -1,9 +1,9 @@
 | int _dos_pathchk (const char *, const struct _dos_comline *, const char *);
 .text
 .even
-.global _dos_comline
-.type _dos_comline,@function
-_dos_comline:
+.global _dos_pathchk
+.type _dos_pathchk,@function
+_dos_pathchk:
 	movem.l	%sp@(4), %d0-%d1/%a0
 	movem.l	%d0-%d1/%a0, %sp@-
 	move.w	#2, %sp@-

--- a/newlib/libc/sys/human68k/libdos/rassign.S
+++ b/newlib/libc/sys/human68k/libdos/rassign.S
@@ -6,7 +6,7 @@
 _dos_rassign:
 	move.l	%sp@(4), %sp@-
 	move.w	#4, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8f
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/s_malloc.S
+++ b/newlib/libc/sys/human68k/libdos/s_malloc.S
@@ -6,7 +6,7 @@
 _dos_s_malloc:
 	move.l	%sp@(8), %sp@-
 	move.w	%sp@(10), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffad
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/s_malloc0.S
+++ b/newlib/libc/sys/human68k/libdos/s_malloc0.S
@@ -9,7 +9,7 @@ _dos_s_malloc0:
 	move.w	%sp@(14), %d0
 	or.w	#0x8000, %d0
 	move.w	%d0, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffad
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/s_mfree.S
+++ b/newlib/libc/sys/human68k/libdos/s_mfree.S
@@ -5,7 +5,7 @@
 .type _dos_s_mfree,@function
 _dos_s_mfree:
 	move.l	%sp@(4), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffae
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/s_process.S
+++ b/newlib/libc/sys/human68k/libdos/s_process.S
@@ -7,7 +7,7 @@ _dos_s_process:
 	movem.l	%sp@(4), %d0-%d1/%a0-%a1
 	movem.l	%d1/%a0-%a1, %sp@-
 	move.w	%d0, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xffaf
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/setenv.S
+++ b/newlib/libc/sys/human68k/libdos/setenv.S
@@ -6,7 +6,7 @@
 _dos_setenv:
 	movem.l	%sp@(4), %d0-%d1/%a0
 	movem.l	%d0-%d1/%a0, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff82
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/setpdb.S
+++ b/newlib/libc/sys/human68k/libdos/setpdb.S
@@ -5,7 +5,7 @@
 .type _dos_psp,@function
 _dos_psp:
 	move.l	%sp@(4), %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff80
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/unlock.S
+++ b/newlib/libc/sys/human68k/libdos/unlock.S
@@ -8,7 +8,7 @@ _dos_unlock:
 	move.l	%sp@(12), %sp@-
 	move.w	%sp@(14), %sp@-
 	move.w	#1, %sp@-
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff8c
 	bras	3f

--- a/newlib/libc/sys/human68k/libdos/verifyg.S
+++ b/newlib/libc/sys/human68k/libdos/verifyg.S
@@ -4,7 +4,7 @@
 .global _dos_verifyg
 .type _dos_verifyg,@function
 _dos_verifyg:
-	cmpi.w	#0x200+14, _vernum+2	| 2.14
+	cmpi.w	#0x200+14, _dos_vernum+2	| 2.14
 	bcss	2f
 	.short	0xff84
 	bras	3f

--- a/newlib/libc/sys/human68k/libiocs/txline.S
+++ b/newlib/libc/sys/human68k/libiocs/txline.S
@@ -1,4 +1,4 @@
-| void _iocs_txline (struct _iocs_tlineptr); /* 1.3, iocs.x */
+| void _iocs_txline (const struct _tlineptr *); /* 1.3, iocs.x */
 .text
 .even
 .global _iocs_txline


### PR DESCRIPTION
Fixes for files, nfiles, dos_filbuf, iocs_b_color_t, iocs_b_intvcs, load, patchchk, loadexec, dos_get_pr, iocs_txyline, vernum, link, unlink and exit.